### PR TITLE
Use extra-libraries to link in python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,32 +42,32 @@ matrix:
   - env: BUILD=stack ARGS=""
     python: 3.8
     compiler: ": #stack default"
-    addons: {apt: {packages: [ pkg-config]}}
+    addons: {apt: {packages: [ pkg-config, python-dev ]}}
 
   - env: BUILD=stack ARGS=""
     python: 3.9
     compiler: ": #stack default"
-    addons: {apt: {packages: [ pkg-config]}}
+    addons: {apt: {packages: [ pkg-config, python-dev ]}}
 
   - env: BUILD=stack ARGS="--resolver lts-9"
     python: 3.9
     compiler: ": #stack 8.0.2"
-    addons: {apt: {packages: [ pkg-config]}}
+    addons: {apt: {packages: [ pkg-config, python-dev ]}}
 
   - env: BUILD=stack ARGS="--resolver lts-11"
     python: 3.9
     compiler: ": #stack 8.2.2"
-    addons: {apt: {packages: [ pkg-config]}}
+    addons: {apt: {packages: [ pkg-config, python-dev ]}}
 
   - env: BUILD=stack ARGS="--resolver lts-12"
     python: 3.9
     compiler: ": #stack 8.4.3"
-    addons: {apt: {packages: [ pkg-config]}}
+    addons: {apt: {packages: [ pkg-config, python-dev ]}}
 
   - env: BUILD=stack ARGS="--resolver nightly"
     python: 3.9
     compiler: ": #stack nightly"
-    addons: {apt: {packages: [ pkg-config]}}
+    addons: {apt: {packages: [ pkg-config, python-dev ]}}
 
   allow_failures:
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,32 +42,32 @@ matrix:
   - env: BUILD=stack ARGS=""
     python: 3.8
     compiler: ": #stack default"
-    addons: {apt: {packages: [ pkg-config, python-dev ]}}
+    addons: {apt: {packages: [ pkg-config]}}
 
   - env: BUILD=stack ARGS=""
     python: 3.9
     compiler: ": #stack default"
-    addons: {apt: {packages: [ pkg-config, python-dev ]}}
+    addons: {apt: {packages: [ pkg-config]}}
 
   - env: BUILD=stack ARGS="--resolver lts-9"
     python: 3.9
     compiler: ": #stack 8.0.2"
-    addons: {apt: {packages: [ pkg-config, python-dev ]}}
+    addons: {apt: {packages: [ pkg-config]}}
 
   - env: BUILD=stack ARGS="--resolver lts-11"
     python: 3.9
     compiler: ": #stack 8.2.2"
-    addons: {apt: {packages: [ pkg-config, python-dev ]}}
+    addons: {apt: {packages: [ pkg-config]}}
 
   - env: BUILD=stack ARGS="--resolver lts-12"
     python: 3.9
     compiler: ": #stack 8.4.3"
-    addons: {apt: {packages: [ pkg-config, python-dev ]}}
+    addons: {apt: {packages: [ pkg-config]}}
 
   - env: BUILD=stack ARGS="--resolver nightly"
     python: 3.9
     compiler: ": #stack nightly"
-    addons: {apt: {packages: [ pkg-config, python-dev ]}}
+    addons: {apt: {packages: [ pkg-config]}}
 
   allow_failures:
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/cpython.cabal
+++ b/cpython.cabal
@@ -89,5 +89,5 @@ test-suite cpython-testsuite
       base > 4.0 && < 5.0
     , text
     , cpython
-  extra-libraries: python3
+  extra-libraries: python
   default-language:    Haskell2010

--- a/cpython.cabal
+++ b/cpython.cabal
@@ -89,5 +89,5 @@ test-suite cpython-testsuite
       base > 4.0 && < 5.0
     , text
     , cpython
-  pkgconfig-depends: python3
+  extra-libraries: python3
   default-language:    Haskell2010


### PR DESCRIPTION
I believe `extra-libraries` does the job of telling the linker where to look for the python C file. Users will need to make sure `python` links to the correct `<Python.h>` (3.X version).

This can be tested locally by making some `test.c` file and then running `gcc test.c -lpython`. If there's a `ld: library not found` error, it's not working (I ran into this before on my fork). Instead of `python` trying `python3` might work.

After this change, running `stack test` locally gives me this output:
```
cpython> test (suite: cpython-testsuite)

Nothing

cpython> Test suite cpython-testsuite passed
```

CI still needs to be fixed, not quite sure how yet (haven't worked much with travis before)