### PR TITLE
Better error messages

### DIFF
--- a/lib/CPython.chs
+++ b/lib/CPython.chs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- Copyright (C) 2009 John Millikin <jmillikin@gmail.com>
 --
@@ -39,6 +40,7 @@ module CPython
 
 #include <hscpython-shim.h>
 
+import           Control.Exception (catch, throwIO, SomeException)
 import           Data.Text (Text)
 
 import           CPython.Internal
@@ -53,7 +55,13 @@ import           CPython.Internal
 -- is a no-op when called for a second time (without calling 'finalize'
 -- first). There is no return value; it is a fatal error if the initialization
 -- fails.
-{# fun Py_Initialize as initialize
+initialize :: IO ()
+initialize = initialize_ `catch`
+  \(e :: SomeException) -> do
+    putStrLn "Couldn't initialize.\nMaybe <Python.h> is missing?"
+    throwIO e
+
+{# fun Py_Initialize as initialize_
   {} -> `()' id #}
 
 -- | Return 'True' when the Python interpreter has been initialized, 'False'

--- a/lib/CPython/Types/Module.chs
+++ b/lib/CPython/Types/Module.chs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- Copyright (C) 2009 John Millikin <jmillikin@gmail.com>
 --
@@ -33,7 +34,8 @@ module CPython.Types.Module
 #include <hscpython-shim.h>
 
 import           Prelude hiding (toInteger)
-import           Data.Text (Text)
+import           Control.Exception (catch, throwIO, SomeException)
+import           Data.Text (Text, unpack)
 
 import           CPython.Internal hiding (new)
 import           CPython.Types.Integer (toInteger)
@@ -115,11 +117,18 @@ addTextConstant m name value = toUnicode value >>= addObject m name
 --
 -- This computation always uses absolute imports.
 importModule :: Text -> IO Module
-importModule name = do
+importModule name = (do
   pyName <- toUnicode name
   withObject pyName $ \namePtr ->
     {# call PyImport_Import as ^ #} namePtr
     >>= stealObject
+  ) `catch` \(e :: SomeException) -> do
+    let moduleName = unpack name
+    putStrLn $
+      "Error: Couldn't import Python module named `" <> moduleName <> "`\n" <>
+      "Maybe it's a typo, or `" <> moduleName <> "` isn't installed?\n" <>
+      "Check with `python -m " <> moduleName <> "`"
+    throwIO e
 
 -- | Reload a module. If an error occurs, an exception is thrown and the old
 -- module still exists.


### PR DESCRIPTION
Getting a start on https://github.com/zsedem/haskell-cpython/issues/13

It's possible that to do error handling correctly, we should do something more comprehensive throughout the library. This only helps on a few of the most commonly used API calls