### PR TITLE
Python 3.12 Unicode API

### DIFF
--- a/cbits/hscpython-shim.c
+++ b/cbits/hscpython-shim.c
@@ -150,13 +150,19 @@ PyObject *hscpython_Py_False()
 
 /* Unicode */
 Py_ssize_t hscpython_PyUnicode_GetSize(PyObject *o)
-{ return PyUnicode_GetSize(o); }
+{ return PyUnicode_GET_LENGTH(o); }
 
-Py_UNICODE *hscpython_PyUnicode_AsUnicode(PyObject *o)
-{ return PyUnicode_AsUnicode(o); }
+wchar_t *hscpython_PyUnicode_AsUnicode(PyObject *o)
+{ wchar_t *wstr;
+	Py_ssize_t actual_size;
+	actual_size = PyUnicode_AsWideChar(o, NULL, 0);
+  wstr = malloc(actual_size);
+  PyUnicode_AsWideChar(o, wstr, actual_size);
+	return wstr;
+}
 
-PyObject *hscpython_PyUnicode_FromUnicode(Py_UNICODE *u, Py_ssize_t size)
-{ return PyUnicode_FromUnicode(u, size); }
+PyObject *hscpython_PyUnicode_FromUnicode(const wchar_t *u, Py_ssize_t size)
+{ return PyUnicode_FromWideChar(u, size); }
 
 PyObject *hscpython_PyUnicode_FromEncodedObject(PyObject *o, const char *enc, const char *err)
 { return PyUnicode_FromEncodedObject(o, enc, err); }

--- a/cbits/hscpython-shim.h
+++ b/cbits/hscpython-shim.h
@@ -54,8 +54,8 @@ PyObject *hscpython_Py_False();
 
 /* Unicode */
 Py_ssize_t hscpython_PyUnicode_GetSize(PyObject *);
-Py_UNICODE *hscpython_PyUnicode_AsUnicode(PyObject *);
-PyObject *hscpython_PyUnicode_FromUnicode(Py_UNICODE *, Py_ssize_t);
+wchar_t *hscpython_PyUnicode_AsUnicode(PyObject *);
+PyObject *hscpython_PyUnicode_FromUnicode(const wchar_t *, Py_ssize_t);
 PyObject *hscpython_PyUnicode_FromEncodedObject(PyObject *, const char *, const char *);
 PyObject *hscpython_PyUnicode_AsEncodedString(PyObject *, const char *, const char *);
 PyObject *hscpython_PyUnicode_FromObject(PyObject *);

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708407374,
-        "narHash": "sha256-EECzarm+uqnNDCwaGg/ppXCO11qibZ1iigORShkkDf0=",
+        "lastModified": 1720368505,
+        "narHash": "sha256-5r0pInVo5d6Enti0YwUSQK4TebITypB42bWy5su3MrQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f33dd27a47ebdf11dc8a5eb05e7c8fbdaf89e73f",
+        "rev": "ab82a9612aa45284d4adf69ee81871a389669a9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
After we've reenabled cpython for Python >= 3.8 in #21 , Python 3.12 deprecated the Unicode API (https://docs.python.org/3.11/c-api/unicode.html#c.PyUnicode_FromUnicode and https://docs.python.org/3.11/c-api/unicode.html#c.PyUnicode_AsUnicode) and CPython failed to build, consequently. This PR ports the relevant functions to the new C-API, namely using CWchar (https://docs.python.org/3.11/c-api/unicode.html#c.PyUnicode_AsWideChar and https://docs.python.org/3.11/c-api/unicode.html#c.PyUnicode_FromWideChar). This allows a uniform handling of the platform specific casts using [C Wide Strings](https://hackage.haskell.org/package/base-4.20.0.1/docs/Foreign-C-String.html#g:4) from base without preprocessor stuff.

It would be great if we could have a new hackage release with those changes :sheep: 