### PR TITLE
Cabal Version Updates

### DIFF
--- a/cpython.cabal
+++ b/cpython.cabal
@@ -36,8 +36,8 @@ library
 
   build-depends:
       base >= 4.0 && < 5.0
-    , bytestring >= 0.11.5 && < 0.12
-    ,  text >= 2.0.2 && < 2.1
+    , bytestring >= 0.11.5 && < 0.13
+    ,  text >= 2.0.2 && < 2.2
 
   build-tools:
     c2hs >= 0.15

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720368505,
-        "narHash": "sha256-5r0pInVo5d6Enti0YwUSQK4TebITypB42bWy5su3MrQ=",
+        "lastModified": 1737110817,
+        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab82a9612aa45284d4adf69ee81871a389669a9e",
+        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR raises the upper bounds of text and bytestring to make it work with latest Hackage releases.

I've also took the opportunity to update the flake.lock.